### PR TITLE
Inserção de REGEX para identificação do processo judicial padrão CNJ

### DIFF
--- a/osint-brazuca-regex.json
+++ b/osint-brazuca-regex.json
@@ -164,7 +164,7 @@
     ],
     "processoCnj": [ 
         { 
-            "regex": "[0-9]{7}\-?[0-9]{2}\.?[0-9]{4}\.?[4-8]\.?[0-9]{2}\.?[0-9]{4}",
+            "regex": "[0-9]{7}\\-?[0-9]{2}\\.?[0-9]{4}\\.?[4-8]\\.?[0-9]{2}\\.?[0-9]{4}",
             "description": "Processos judiciais com numeração padrão do CNJ, em estrutura formatada (com caracteres especiais) ou não"
         } 
     ]

--- a/osint-brazuca-regex.json
+++ b/osint-brazuca-regex.json
@@ -164,7 +164,7 @@
     ],
     "processoCnj": [ 
         { 
-            "regex": "[0-9]{7}\-?[0-9]{2}\.?[0-9]{4}\.?8\.?[0-9]{2}\.?[0-9]{4}",
+            "regex": "[0-9]{7}\-?[0-9]{2}\.?[0-9]{4}\.?[4-8]\.?[0-9]{2}\.?[0-9]{4}",
             "description": "Processos judiciais com numeração padrão do CNJ, em estrutura formatada (com caracteres especiais) ou não"
         } 
     ]

--- a/osint-brazuca-regex.json
+++ b/osint-brazuca-regex.json
@@ -161,5 +161,11 @@
             "regex": "(?=.*[A-Z])(?=.*[a-z])(?=.*[\d])(?=.*[@#$%&*!-+&*]).{8,20}",
             "description": "Validador de senhas com tamanho entre 8 e 20 dígitos e com letras maiúsculas, minúsculas, números e caracteres especiais"
         } 
+    ],
+    "processoCnj": [ 
+        { 
+            "regex": "[0-9]{7}\-?[0-9]{2}\.?[0-9]{4}\.?8\.?[0-9]{2}\.?[0-9]{4}",
+            "description": "Processos judiciais com numeração padrão do CNJ, em estrutura formatada (com caracteres especiais) ou não"
+        } 
     ]
 }


### PR DESCRIPTION
Aceitando os formatos 0000194-84.2022.8.05.0043 e 00001948420228050043 padrão dos números processuais CNJ, servindo desde processos da justiça estadual (dígito 8), quanto para justiça federal (dígito 4), trabalhista (dígitio 5) e outras.