### PR TITLE
Add Regex de Nome Completo estilo nomes brasileiros

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,10 @@
 </details>
 
 
+## Nome Completo
+```
+^[-ʼ'A-ú ]+$
+```
 
 ## RG - Registro Geral 
 ```

--- a/osint-brazuca-regex.json
+++ b/osint-brazuca-regex.json
@@ -211,6 +211,12 @@
             "description": "Media Access Control address"
         }
     ],
+    "nomeCompleto": [
+        {
+            "regex": "^[-ʼ'A-ú ]+$",
+            "description": "Nome completo com acento e conectores"
+        }
+    ],
     "passaporte": [
         {
             "regex": "^[A-Z]{2}\\d{6}$",


### PR DESCRIPTION
Regex de nome completo em padrão brasileiro sempre é uma questão sensível pela diversidade de nossa população.

Regex Nome Completo
```javascript
^[-ʼ'A-ú ]+$
```
### Exemplo de Teste
![image](https://github.com/osintbrazuca/osint-brazuca-regex/assets/136408366/dcfc42df-7eda-42a3-9797-5e66c129a16f)

Referente à #31 