### PR TITLE
Atualização da chave pix

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,7 +356,7 @@
 
 ## Chave PIX 
 ```
-([0-9]{14})(br.gov.bcb.(|-)pix).*(6304)([0-9a-zA-Z]{4})
+([0-9]{14,20})([bB][rR]\.[gG][oO][vV]\.[bB][cC][bB]\.[pP][iI][xX]).*(6304)([0-9a-zA-Z]{4})
 ```
 
 ## Chave PIX Aleatória

--- a/osint-brazuca-regex.json
+++ b/osint-brazuca-regex.json
@@ -219,7 +219,7 @@
     ],
     "pixChave": [
         {
-            "regex": "([0-9]{14})(br.gov.bcb.(|-)pix).*(6304)([0-9a-zA-Z]{4})",
+            "regex": "([0-9]{14,20})([bB][rR]\.[gG][oO][vV]\.[bB][cC][bB]\.[pP][iI][xX]).*(6304)([0-9a-zA-Z]{4})",
             "description": "Chave PIX"
         }
     ],

--- a/osint-brazuca-regex.json
+++ b/osint-brazuca-regex.json
@@ -219,7 +219,7 @@
     ],
     "pixChave": [
         {
-            "regex": "([0-9]{14,20})([bB][rR]\.[gG][oO][vV]\.[bB][cC][bB]\.[pP][iI][xX]).*(6304)([0-9a-zA-Z]{4})",
+            "regex": "([0-9]{14,20})([bB][rR]\\.[gG][oO][vV]\\.[bB][cC][bB]\\.[pP][iI][xX]).*(6304)([0-9a-zA-Z]{4})",
             "description": "Chave PIX"
         }
     ],


### PR DESCRIPTION
Tentei utilizar o regex da chave pix que está atualmente no projeto, mas tive alguns exemplos (que eu tenho certeza que funcionam para transferencias), que não davam match.

Atualizei e agora tanto as chaves que já funcionavam quanto algumas de formato um pouco diferente também funcionam.

As mudanças consistem na:

- Flexibilização da quantidade de números antes do link (entre 14 e 20)
- Aceitação de letras maiúsculas e minúsculas do link.